### PR TITLE
fix: Config API refresh rewards no longer crashes the bot on a channel without channel points or when rewards mode is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [TwitchMIDI]
 
+## [3.1.1] - 2026-06-20
+### Fixed
+- Config API /refreshConfig?file=rewards no longer crashes the bot when called on a channel without channel points or when rewards mode is off
+
 ## [3.1.0] - 2026-06-20
 ### Added
 - New .env flag ALLOW_MANUAL_LOOPS to control whether users can request arbitrary chord progressions via !sendloop. When disabled, only predefined chord progression aliases from aliases.json are allowed (e.g. "!sendloop pop" works but "!sendloop C G Amin F" does not)
@@ -551,6 +555,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [TwitchMIDI]: https://github.com/rafaelpernil2/TwitchMIDI
+[3.1.1]: https://github.com/rafaelpernil2/TwitchMIDI/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/rafaelpernil2/TwitchMIDI/compare/v3.0.3...v3.1.0
 [3.0.3]: https://github.com/rafaelpernil2/TwitchMIDI/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/rafaelpernil2/TwitchMIDI/compare/v3.0.1...v3.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twitch-midi",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twitch-midi",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
         "@twurple/api": "7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-midi",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A Twitch bot that allows viewers to control your MIDI setup",
   "type": "module",
   "main": "lib/index.js",

--- a/src/configuration/api/handler.ts
+++ b/src/configuration/api/handler.ts
@@ -66,11 +66,16 @@ function _onRequest(
                         // Validate request
                         if (configFileMap[queryFile] == null) return _buildResponse(res, 400, i18n.t('API_ERROR_FILE'));
 
-                        // If it is a reward, reload them, otherwise, refresh the file
-                        if (queryFile === 'rewards') {
-                            await reloadRewards(authProvider, targetChannel);
-                        } else {
-                            await configFileMap[queryFile].fetchDB();
+                        try {
+                            // If it is a reward, reload them, otherwise, refresh the file
+                            if (queryFile === 'rewards') {
+                                await reloadRewards(authProvider, targetChannel);
+                            } else {
+                                await configFileMap[queryFile].fetchDB();
+                            }
+                        } catch (error) {
+                            // Reloading rewards can fail (e.g. a channel without channel points). Return an error instead of crashing
+                            return _buildResponse(res, 400, error instanceof Error ? error.message : i18n.t('API_GENERIC_ERROR'));
                         }
 
                         // Happy path, all OK! :)

--- a/src/twitch/rewards/handler.ts
+++ b/src/twitch/rewards/handler.ts
@@ -84,27 +84,27 @@ export async function createRewards(authProvider: RefreshingAuthProvider, userna
  * @param { isEnabled } optionData Boolean to activate/deactivate rewards
  */
 export async function toggleRewardsStatus(authProvider: RefreshingAuthProvider, username: string, { isEnabled }: { isEnabled: boolean }): Promise<void> {
-    const apiClient = _getApiClient(authProvider);
-    const userId = await _getBroadcasterId(authProvider, username);
-    const allRewards = await apiClient.channelPoints.getCustomRewards(userId, true);
-
-    // Only treat our rewards
-    const validRewards = isEnabled ? allRewards.filter(({ title }) => REWARDS_DB.select(REWARD_TITLE_COMMAND, title) != null) : allRewards;
-    const updatePromiseMap = validRewards.map((reward) => {
-        const [command = '', cost] = REWARDS_DB.select(REWARD_TITLE_COMMAND, reward.title) ?? [];
-
-        // Re-check if it is a macro command
-        const [parsedCommand] = getCommand(command);
-        const userInputRequired = parsedCommand != null; // Single commands require user input while macros do not
-
-        return apiClient.channelPoints.updateCustomReward(userId, reward.id, { ...reward, userInputRequired, isEnabled, cost });
-    });
     try {
+        const apiClient = _getApiClient(authProvider);
+        const userId = await _getBroadcasterId(authProvider, username);
+        const allRewards = await apiClient.channelPoints.getCustomRewards(userId, true);
+
+        // Only treat our rewards
+        const validRewards = isEnabled ? allRewards.filter(({ title }) => REWARDS_DB.select(REWARD_TITLE_COMMAND, title) != null) : allRewards;
+        const updatePromiseMap = validRewards.map((reward) => {
+            const [command = '', cost] = REWARDS_DB.select(REWARD_TITLE_COMMAND, reward.title) ?? [];
+
+            // Re-check if it is a macro command
+            const [parsedCommand] = getCommand(command);
+            const userInputRequired = parsedCommand != null; // Single commands require user input while macros do not
+
+            return apiClient.channelPoints.updateCustomReward(userId, reward.id, { ...reward, userInputRequired, isEnabled, cost });
+        });
         await Promise.all(updatePromiseMap);
+        areRewardsOn = isEnabled;
     } catch {
-        // Implement if needed
+        // Channel may not have channel points (e.g. non-affiliate) or the API call failed; ignore instead of crashing
     }
-    areRewardsOn = isEnabled;
 }
 
 /**


### PR DESCRIPTION
## 3.1.1 - 2026-06-20
### Fixed
- Config API /refreshConfig?file=rewards no longer crashes the bot when called on a channel without channel points or when rewards mode is off